### PR TITLE
Build all tests that will be run by run_unit_tests else we will fail

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,13 +30,16 @@ check_PROGRAMS += vector_pde_unit
 check_PROGRAMS += parallel_unit
 check_PROGRAMS += pde_unit
 
+AM_TESTS_ENVIRONMENT =
 if CXX14_ENABLED
   check_PROGRAMS += dualnamedarray_unit
   check_PROGRAMS += namedindexarray_unit
+  AM_TESTS_ENVIRONMENT += TEST_CXX14=yes; export TEST_CXX14;
 endif
 
 if CXX11_ENABLED
   check_PROGRAMS += physics_unit
+  AM_TESTS_ENVIRONMENT += TEST_CXX11=yes; export TEST_CXX11;
 endif
 
 AM_CPPFLAGS  =

--- a/test/run_unit_tests.sh.in
+++ b/test/run_unit_tests.sh.in
@@ -5,15 +5,27 @@ set -e
 # dynamic_sparse_vector_navier_unit and shadow_dynamic_sparse_vector_navier_unit
 # are currently broken
 
-for prog in compare_types complex_derivs derivs divgrad dualnamedarray \
-    dynamic_sparse_vector_pde identities instantiations main namedindexarray \
-    nd_derivs parallel pde physics shadow_dynamic_sparse_vector_pde \
+run_program() {
+    echo $METAPHYSICL_RUN ./$1_unit
+    $METAPHYSICL_RUN ./$1_unit
+    }
+
+
+for prog in compare_types complex_derivs derivs divgrad \
+    dynamic_sparse_vector_pde identities instantiations main \
+    nd_derivs parallel pde shadow_dynamic_sparse_vector_pde \
     shadow_sparse_struct_navier shadow_sparse_struct_pde \
     shadow_sparse_vector_navier shadow_sparse_vector_pde shadow_vector_navier \
     shadow_vector_pde sparse_derivs sparse_identities sparse_struct_navier \
     sparse_struct_pde sparse_vector_navier sparse_vector_pde testheaders testopt \
     vector_navier vector_pde; do
-
-    echo $METAPHYSICL_RUN ./${prog}_unit
-    $METAPHYSICL_RUN ./${prog}_unit
+    run_program $prog
 done
+
+if test x${TEST_CXX11} = xyes; then
+    run_program physics
+fi
+if test x${TEST_CXX14} = xyes; then
+    run_program dualnamedarray
+    run_program namedindexarray
+fi


### PR DESCRIPTION
If we really want coverage of pre-c++11 and pre-c++14 we may have to really mess with CIVET