### PR TITLE
Unit test options for disabling long double tests

### DIFF
--- a/test/derivs_unit.C
+++ b/test/derivs_unit.C
@@ -360,15 +360,26 @@ int vectester (void)
   return returnval;
 }
 
-int main(void)
+int main(int argc, char * argv[])
 {
   int returnval = 0;
-  returnval = returnval || vectester<NumberArray<N, DualNumber<float> > >();
-  returnval = returnval || vectester<NumberArray<N, DualNumber<double> > >();
-  returnval = returnval || vectester<NumberArray<N, DualNumber<long double> > >();
   returnval = returnval || scalartester<NumberArray<N, float> >();
+  returnval = returnval || vectester<NumberArray<N, DualNumber<float> > >();
+
   returnval = returnval || scalartester<NumberArray<N, double> >();
-  returnval = returnval || scalartester<NumberArray<N, long double> >();
+  returnval = returnval || vectester<NumberArray<N, DualNumber<double> > >();
+
+  bool use_long_double = true;
+  std::string disarg = "--disable-long-double";
+  for (int i = 1; i < argc; ++i)
+    if (disarg == argv[i])
+      use_long_double = false;
+
+  if (use_long_double)
+    {
+      returnval = returnval || scalartester<NumberArray<N, long double> >();
+      returnval = returnval || vectester<NumberArray<N, DualNumber<long double> > >();
+    }
 
   // We no longer treat vectors like arrays for built-in functions, so
   // most of the identities above make no sense.

--- a/test/divgrad_unit.C
+++ b/test/divgrad_unit.C
@@ -112,13 +112,21 @@ bool dense_tester()
   return vectester(zero_vec, unit_x, unit_y, unit_z);
 }
 
-int main(void)
+int main(int argc, char * argv[])
 {
   int returnval = 0;
 
   returnval = returnval || dense_tester<float>();
   returnval = returnval || dense_tester<double>();
-  returnval = returnval || dense_tester<long double>();
+
+  bool use_long_double = true;
+  std::string disarg = "--disable-long-double";
+  for (int i = 1; i < argc; ++i)
+    if (disarg == argv[i])
+      use_long_double = false;
+
+  if (use_long_double)
+    returnval = returnval || dense_tester<long double>();
 
 
 #if 0

--- a/test/identities_unit.C
+++ b/test/identities_unit.C
@@ -106,12 +106,20 @@ int vectester (void)
   return returnval;
 }
 
-int main(void)
+int main(int argc, char * argv[])
 {
   int returnval = 0;
   returnval = returnval || vectester<NumberArray<N, float> >();
   returnval = returnval || vectester<NumberArray<N, double> >();
-  returnval = returnval || vectester<NumberArray<N, long double> >();
+
+  bool use_long_double = true;
+  std::string disarg = "--disable-long-double";
+  for (int i = 1; i < argc; ++i)
+    if (disarg == argv[i])
+      use_long_double = false;
+
+  if (use_long_double)
+    returnval = returnval || vectester<NumberArray<N, long double> >();
 
   // We no longer treat vectors like arrays for built-in functions, so
   // most of the identities above make no sense.

--- a/test/main_unit.C
+++ b/test/main_unit.C
@@ -14,8 +14,8 @@ struct print_functor {
 
 int main(void)
 {
-  const RawType<const ShadowNumber<double, long double> >::value_type testin = 0;
-  double testout = testin;
+  const RawType<const ShadowNumber<float, double> >::value_type testin = 0;
+  float testout = testin;
 
   if (testout)
     metaphysicl_error();

--- a/test/run_unit_tests.sh.in
+++ b/test/run_unit_tests.sh.in
@@ -6,8 +6,8 @@ set -e
 # are currently broken
 
 run_program() {
-    echo $METAPHYSICL_RUN ./$1_unit
-    $METAPHYSICL_RUN ./$1_unit
+    echo $METAPHYSICL_RUN ./$1_unit $METAPHYSICL_OPTIONS
+    $METAPHYSICL_RUN ./$1_unit $METAPHYSICL_OPTIONS
     }
 
 

--- a/test/sparse_derivs_unit.C
+++ b/test/sparse_derivs_unit.C
@@ -207,7 +207,7 @@ int vectester (Vector zerovec)
   return returnval;
 }
 
-int main(void)
+int main(int argc, char * argv[])
 {
   int returnval = 0;
   /*
@@ -225,12 +225,6 @@ int main(void)
   returnval = returnval || vectester(SparseNumberArrayOf
     <N, 0, DualNumber<float>, 1, DualNumber<float>,
         2, DualNumber<float>, 3, DualNumber<float> >::type());
-  returnval = returnval || vectester(SparseNumberArrayOf
-    <N, 0, DualNumber<double>, 1, DualNumber<double>,
-        2, DualNumber<double>, 3, DualNumber<double> >::type());
-  returnval = returnval || vectester(SparseNumberArrayOf
-    <N, 0, DualNumber<long double>, 1, DualNumber<long double>,
-        2, DualNumber<long double>, 3, DualNumber<long double> >::type());
 
   DynamicSparseNumberArray<DualNumber<float>, unsigned int> float_dsna;
     float_dsna.resize(4);
@@ -239,26 +233,24 @@ int main(void)
     float_dsna.raw_index(3) = 3;
   returnval = returnval || vectester(float_dsna);
 
-  DynamicSparseNumberArray<DualNumber<double>, unsigned int> double_dsna;
-    double_dsna.resize(4);
-    double_dsna.raw_index(1) = 1;
-    double_dsna.raw_index(2) = 2;
-    double_dsna.raw_index(3) = 3;
-  returnval = returnval || vectester(double_dsna);
-
-  DynamicSparseNumberArray<DualNumber<long double>, unsigned int> long_double_dsna;
-    long_double_dsna.resize(4);
-    long_double_dsna.raw_index(1) = 1;
-    long_double_dsna.raw_index(2) = 2;
-    long_double_dsna.raw_index(3) = 3;
-  returnval = returnval || vectester(long_double_dsna);
-
   SemiDynamicSparseNumberArray<DualNumber<float>, unsigned int, NWrapper<4>> float_sdsna;
     float_dsna.resize(4);
     float_dsna.raw_index(1) = 1;
     float_dsna.raw_index(2) = 2;
     float_dsna.raw_index(3) = 3;
   returnval = returnval || vectester(float_sdsna);
+
+
+  returnval = returnval || vectester(SparseNumberArrayOf
+    <N, 0, DualNumber<double>, 1, DualNumber<double>,
+        2, DualNumber<double>, 3, DualNumber<double> >::type());
+
+  DynamicSparseNumberArray<DualNumber<double>, unsigned int> double_dsna;
+    double_dsna.resize(4);
+    double_dsna.raw_index(1) = 1;
+    double_dsna.raw_index(2) = 2;
+    double_dsna.raw_index(3) = 3;
+  returnval = returnval || vectester(double_dsna);
 
   SemiDynamicSparseNumberArray<DualNumber<double>, unsigned int, NWrapper<4>> double_sdsna;
     double_dsna.resize(4);
@@ -267,12 +259,33 @@ int main(void)
     double_dsna.raw_index(3) = 3;
   returnval = returnval || vectester(double_sdsna);
 
-  SemiDynamicSparseNumberArray<DualNumber<long double>, unsigned int, NWrapper<4>> long_double_sdsna;
-    long_double_dsna.resize(4);
-    long_double_dsna.raw_index(1) = 1;
-    long_double_dsna.raw_index(2) = 2;
-    long_double_dsna.raw_index(3) = 3;
-  returnval = returnval || vectester(long_double_sdsna);
+
+  bool use_long_double = true;
+  std::string disarg = "--disable-long-double";
+  for (int i = 1; i < argc; ++i)
+    if (disarg == argv[i])
+      use_long_double = false;
+
+  if (use_long_double)
+    {
+      returnval = returnval || vectester(SparseNumberArrayOf
+        <N, 0, DualNumber<long double>, 1, DualNumber<long double>,
+            2, DualNumber<long double>, 3, DualNumber<long double> >::type());
+
+      DynamicSparseNumberArray<DualNumber<long double>, unsigned int> long_double_dsna;
+        long_double_dsna.resize(4);
+        long_double_dsna.raw_index(1) = 1;
+        long_double_dsna.raw_index(2) = 2;
+        long_double_dsna.raw_index(3) = 3;
+      returnval = returnval || vectester(long_double_dsna);
+
+      SemiDynamicSparseNumberArray<DualNumber<long double>, unsigned int, NWrapper<4>> long_double_sdsna;
+        long_double_dsna.resize(4);
+        long_double_dsna.raw_index(1) = 1;
+        long_double_dsna.raw_index(2) = 2;
+        long_double_dsna.raw_index(3) = 3;
+      returnval = returnval || vectester(long_double_sdsna);
+    }
 
 // Many of the functions we test don't make sense for mathematical vectors
 /*

--- a/test/sparse_identities_unit.C
+++ b/test/sparse_identities_unit.C
@@ -146,12 +146,75 @@ int dynamic_tester (Vector zerovec)
   return returnval;
 }
 
-int main(void)
+int main(int argc, char * argv[])
 {
   int returnval = 0;
+
   returnval = returnval || vectester(NumberArray<N, float>());
+
+  returnval = returnval ||
+              vectester(SparseNumberArrayOf
+                          <4, 0, float, 1, float,
+                              2, float, 3, float>::type());
+
+  returnval = returnval ||
+              vectester(SparseNumberVectorOf
+                          <4, 0, float, 1, float,
+                              2, float, 3, float>::type());
+
+  DynamicSparseNumberArray<float, unsigned int> float_dsna;
+  returnval = returnval || dynamic_tester(float_dsna);
+
+  DynamicSparseNumberVector<float, unsigned int> float_dsnv;
+  returnval = returnval || dynamic_tester(float_dsna);
+
+
   returnval = returnval || vectester(NumberArray<N, double>());
-  returnval = returnval || vectester(NumberArray<N, long double>());
+
+  returnval = returnval ||
+              vectester(SparseNumberArrayOf
+                          <4, 0, double, 1, double,
+                              2, double, 3, double>::type());
+
+  returnval = returnval ||
+              vectester(SparseNumberVectorOf
+                          <4, 0, double, 1, double,
+                              2, double, 3, double>::type());
+
+  DynamicSparseNumberArray<double, unsigned int> double_dsna;
+  returnval = returnval || dynamic_tester(double_dsna);
+
+  DynamicSparseNumberVector<double, unsigned int> double_dsnv;
+  returnval = returnval || dynamic_tester(double_dsnv);
+
+
+  bool use_long_double = true;
+  std::string disarg = "--disable-long-double";
+  for (int i = 1; i < argc; ++i)
+    if (disarg == argv[i])
+      use_long_double = false;
+
+  if (use_long_double)
+    {
+      returnval = returnval || vectester(NumberArray<N, long double>());
+
+      returnval = returnval ||
+                  vectester(SparseNumberArrayOf
+                              <4, 0, long double, 1, long double,
+                                  2, long double, 3, long double>::type());
+
+      returnval = returnval ||
+                  vectester(SparseNumberVectorOf
+                              <4, 0, long double, 1, long double,
+                                  2, long double, 3, long double>::type());
+
+      DynamicSparseNumberArray<long double, unsigned int> long_double_dsna;
+      returnval = returnval || dynamic_tester(long_double_dsna);
+
+      DynamicSparseNumberVector<long double, unsigned int> long_double_dsnv;
+      returnval = returnval || dynamic_tester(long_double_dsnv);
+    }
+
 
   // We no longer treat vectors like arrays for built-in functions, so
   // most of the identities above make no sense.
@@ -161,49 +224,6 @@ int main(void)
   returnval = returnval || vectester(NumberVector<N, long double>());
   */
 
-  returnval = returnval ||
-              vectester(SparseNumberArrayOf
-                          <4, 0, float, 1, float,
-                              2, float, 3, float>::type());
-  returnval = returnval ||
-              vectester(SparseNumberArrayOf
-                          <4, 0, double, 1, double,
-                              2, double, 3, double>::type());
-  returnval = returnval ||
-              vectester(SparseNumberArrayOf
-                          <4, 0, long double, 1, long double,
-                              2, long double, 3, long double>::type());
-
-  returnval = returnval ||
-              vectester(SparseNumberVectorOf
-                          <4, 0, float, 1, float,
-                              2, float, 3, float>::type());
-  returnval = returnval ||
-              vectester(SparseNumberVectorOf
-                          <4, 0, double, 1, double,
-                              2, double, 3, double>::type());
-  returnval = returnval ||
-              vectester(SparseNumberVectorOf
-                          <4, 0, long double, 1, long double,
-                              2, long double, 3, long double>::type());
-
-  DynamicSparseNumberArray<float, unsigned int> float_dsna;
-  returnval = returnval || dynamic_tester(float_dsna);
-
-  DynamicSparseNumberArray<double, unsigned int> double_dsna;
-  returnval = returnval || dynamic_tester(double_dsna);
-
-  DynamicSparseNumberArray<long double, unsigned int> long_double_dsna;
-  returnval = returnval || dynamic_tester(long_double_dsna);
-
-  DynamicSparseNumberVector<float, unsigned int> float_dsnv;
-  returnval = returnval || dynamic_tester(float_dsna);
-
-  DynamicSparseNumberVector<double, unsigned int> double_dsnv;
-  returnval = returnval || dynamic_tester(double_dsnv);
-
-  DynamicSparseNumberVector<long double, unsigned int> long_double_dsnv;
-  returnval = returnval || dynamic_tester(long_double_dsnv);
 
   return returnval;
 }


### PR DESCRIPTION
`METAPHYSICL_RUN='libtool --mode=execute valgrind' make check` fails on
systems with 80-bit long double, because valgrind doesn't support 80-bit
arithmetic and forces a bunch of calculations down to 64-bit instead.
But with this commit, we can `METAPHYSICL_OPTIONS=--disable-long-double`
too and at least get valgrind to run on the float and double (and of
course various integer) tests.