### PR TITLE
Use SemiPermanent for derived StandardTypes

### DIFF
--- a/src/numerics/include/metaphysicl/parallel_dualnumber.h
+++ b/src/numerics/include/metaphysicl/parallel_dualnumber.h
@@ -55,48 +55,58 @@ class StandardType<
 public:
   explicit StandardType(const DualNumber<T, D, asd> * example = nullptr)
   {
-    // We need an example for MPI_Address to use
-    static const DualNumber<T, D, asd> p(0);
-    if (!example)
-      example = &p;
-
 #ifdef TIMPI_HAVE_MPI
+    static data_type static_type = MPI_DATATYPE_NULL;
+    if (static_type == MPI_DATATYPE_NULL)
+      {
+        // We need an example for MPI_Address to use
+        static const DualNumber<T, D, asd> p(0);
+        if (!example)
+          example = &p;
 
-    // Get the sub-data-types, and make sure they live long enough
-    // to construct the derived type
-    StandardType<T> d1(&example->value());
-    StandardType<D> d2(&example->derivatives());
+        // Get the sub-data-types, and make sure they live long enough
+        // to construct the derived type
+        StandardType<T> d1(&example->value());
+        StandardType<D> d2(&example->derivatives());
 
-    MPI_Datatype types[] = {(data_type)d1, (data_type)d2};
-    int blocklengths[] = {1, 1};
-    MPI_Aint displs[2], start;
+        MPI_Datatype types[] = {(data_type)d1, (data_type)d2};
+        int blocklengths[] = {1, 1};
+        MPI_Aint displs[2], start;
 
-    timpi_call_mpi(MPI_Get_address(const_cast<DualNumber<T, D, asd> *>(example), &start));
-    timpi_call_mpi(MPI_Get_address(const_cast<T *>(&example->value()), &displs[0]));
-    timpi_call_mpi(MPI_Get_address(const_cast<D *>(&example->derivatives()), &displs[1]));
-    displs[0] -= start;
-    displs[1] -= start;
+        timpi_call_mpi(MPI_Get_address(const_cast<DualNumber<T, D, asd> *>(example), &start));
+        timpi_call_mpi(MPI_Get_address(const_cast<T *>(&example->value()), &displs[0]));
+        timpi_call_mpi(MPI_Get_address(const_cast<D *>(&example->derivatives()), &displs[1]));
+        displs[0] -= start;
+        displs[1] -= start;
 
-    // create a prototype structure
-    MPI_Datatype tmptype;
-    timpi_call_mpi(MPI_Type_create_struct(2, blocklengths, displs, types, &tmptype));
-    timpi_call_mpi(MPI_Type_commit(&tmptype));
+        // create a prototype structure
+        MPI_Datatype tmptype;
+        timpi_call_mpi(MPI_Type_create_struct(2, blocklengths, displs, types, &tmptype));
+        timpi_call_mpi(MPI_Type_commit(&tmptype));
 
-    // resize the structure type to account for padding, if any
-    timpi_call_mpi(MPI_Type_create_resized(tmptype, 0, sizeof(DualNumber<T, D, asd>), &_datatype));
-    timpi_call_mpi(MPI_Type_free(&tmptype));
+        // resize the structure type to account for padding, if any
+        timpi_call_mpi(MPI_Type_create_resized(tmptype, 0, sizeof(DualNumber<T, D, asd>), &static_type));
+        timpi_call_mpi(MPI_Type_free(&tmptype));
 
-    this->commit();
-
+        SemiPermanent::add
+          (std::make_unique<ManageType>(static_type));
+      }
+    _datatype = static_type;
+#else
+    timpi_ignore(example);
 #endif // TIMPI_HAVE_MPI
   }
 
   StandardType(const StandardType<DualNumber<T, D, asd>> & timpi_mpi_var(t))
   {
-    timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+    _datatype = t._datatype;
   }
 
-  ~StandardType() { this->free(); }
+  StandardType & operator=(StandardType & t)
+  {
+    _datatype = t._datatype;
+    return *this;
+  }
 
   static const bool is_fixed_type = true;
 };

--- a/src/numerics/include/metaphysicl/parallel_semidynamicsparsenumberarray.h
+++ b/src/numerics/include/metaphysicl/parallel_semidynamicsparsenumberarray.h
@@ -41,55 +41,65 @@ public:
   explicit StandardType(
       const MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N> * example = nullptr)
   {
-    // We need an example for MPI_Address to use
-    static const MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N> p;
-    if (!example)
-      example = &p;
-
 #ifdef TIMPI_HAVE_MPI
+    static data_type static_type = MPI_DATATYPE_NULL;
+    if (static_type == MPI_DATATYPE_NULL)
+      {
+        // We need an example for MPI_Address to use
+        static const MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N> p;
+        if (!example)
+          example = &p;
 
-    // Get the sub-data-types, and make sure they live long enough
-    // to construct the derived type
-    StandardType<MetaPhysicL::DynamicStdArrayWrapper<T, N>> d1(&example->nude_data());
-    StandardType<MetaPhysicL::DynamicStdArrayWrapper<I, N>> d2(&example->nude_indices());
+        // Get the sub-data-types, and make sure they live long enough
+        // to construct the derived type
+        StandardType<MetaPhysicL::DynamicStdArrayWrapper<T, N>> d1(&example->nude_data());
+        StandardType<MetaPhysicL::DynamicStdArrayWrapper<I, N>> d2(&example->nude_indices());
 
-    MPI_Datatype types[] = {(data_type)d1, (data_type)d2};
-    int blocklengths[] = {1, 1};
-    MPI_Aint displs[2], start;
+        MPI_Datatype types[] = {(data_type)d1, (data_type)d2};
+        int blocklengths[] = {1, 1};
+        MPI_Aint displs[2], start;
 
-    timpi_call_mpi(MPI_Get_address(
-        const_cast<MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N> *>(example), &start));
-    timpi_call_mpi(MPI_Get_address(
-        const_cast<MetaPhysicL::DynamicStdArrayWrapper<T, N> *>(&example->nude_data()),
-        &displs[0]));
-    timpi_call_mpi(MPI_Get_address(
-        const_cast<MetaPhysicL::DynamicStdArrayWrapper<I, N> *>(&example->nude_indices()),
-        &displs[1]));
-    displs[0] -= start;
-    displs[1] -= start;
+        timpi_call_mpi(MPI_Get_address(
+            const_cast<MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N> *>(example), &start));
+        timpi_call_mpi(MPI_Get_address(
+            const_cast<MetaPhysicL::DynamicStdArrayWrapper<T, N> *>(&example->nude_data()),
+            &displs[0]));
+        timpi_call_mpi(MPI_Get_address(
+            const_cast<MetaPhysicL::DynamicStdArrayWrapper<I, N> *>(&example->nude_indices()),
+            &displs[1]));
+        displs[0] -= start;
+        displs[1] -= start;
 
-    // create a prototype structure
-    MPI_Datatype tmptype;
-    timpi_call_mpi(MPI_Type_create_struct(2, blocklengths, displs, types, &tmptype));
-    timpi_call_mpi(MPI_Type_commit(&tmptype));
+        // create a prototype structure
+        MPI_Datatype tmptype;
+        timpi_call_mpi(MPI_Type_create_struct(2, blocklengths, displs, types, &tmptype));
+        timpi_call_mpi(MPI_Type_commit(&tmptype));
 
-    // resize the structure type to account for padding, if any
-    timpi_call_mpi(MPI_Type_create_resized(
-        tmptype, 0, sizeof(MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N>), &_datatype));
-    timpi_call_mpi(MPI_Type_free(&tmptype));
+        // resize the structure type to account for padding, if any
+        timpi_call_mpi(MPI_Type_create_resized(
+            tmptype, 0, sizeof(MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N>), &static_type));
+        timpi_call_mpi(MPI_Type_free(&tmptype));
 
-    this->commit();
-
+        SemiPermanent::add
+          (std::make_unique<ManageType>(static_type));
+      }
+    _datatype = static_type;
+#else
+    timpi_ignore(example);
 #endif // TIMPI_HAVE_MPI
   }
 
   StandardType(
       const StandardType<MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N>> & timpi_mpi_var(t))
   {
-    timpi_call_mpi(MPI_Type_dup(t._datatype, &_datatype));
+    _datatype = t._datatype;
   }
 
-  ~StandardType() { this->free(); }
+  StandardType & operator=(StandardType & t)
+  {
+    _datatype = t._datatype;
+    return *this;
+  }
 
   static const bool is_fixed_type = true;
 };

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -17,7 +17,7 @@
   metaphysicl_error()
 
 #define METAPHYSICL_UNIT_FP_ASSERT(test, true_value, tolerance)                                    \
-  if (!(test < true_value + tolerance && test > true_value - tolerance))               \
+  if (!(test < true_value + tolerance && test > true_value - tolerance))                           \
   metaphysicl_error()
 
 #define TOLERANCE 1e-12
@@ -57,6 +57,16 @@ testContainerAllGather()
   }
 }
 
+template <typename NonBuiltin>
+void
+testStandardTypeAssignment()
+{
+  NonBuiltin ex{};
+  StandardType<NonBuiltin> a(&ex);
+  StandardType<NonBuiltin> b(&ex);
+  a = b;
+}
+
 int
 main(int argc, const char * const * argv)
 {
@@ -68,12 +78,17 @@ main(int argc, const char * const * argv)
   testContainerAllGather<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, true>();
   testContainerAllGather<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, false>();
 
+  testStandardTypeAssignment<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>>();
+  testStandardTypeAssignment<DynamicStdArrayWrapper<double, NWrapper<50>>>();
+  testStandardTypeAssignment<DualNumber<double>>();
+
   return 0;
 }
 
 #else
 
-int main()
+int
+main()
 {
   return 0;
 }


### PR DESCRIPTION
This should fix the same potential issues as #5 but more efficiently, at the cost of only being compatible with the newest TIMPI.