### PR TITLE
When we exceed our container size, we'll throw

### DIFF
--- a/src/utilities/include/metaphysicl/dynamic_std_array_wrapper.h
+++ b/src/utilities/include/metaphysicl/dynamic_std_array_wrapper.h
@@ -121,7 +121,8 @@ public:
 
   void resize(size_type new_size)
   {
-    metaphysicl_assert(new_size <= N);
+    if (new_size > N)
+      metaphysicl_error();
     _dynamic_n = new_size;
   }
 


### PR DESCRIPTION
The big question here was on whether this change would incur too much
expense ... and the answer appears to be no. In a run of our virtual
pebble-bed FHR, pre-throw took 37.1 seconds and post-throw took 37.7
seconds, so probably even within the noise. Moreover, the profile didn't
show `resize` as being a function of import; the flat percent
contribution was 0.053%.