### PR TITLE
Implement ReplaceAlgebraicType

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,0 @@
-DisableFormat: true
-SortIncludes: false

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ test/run_unit_tests.sh
 build
 installed
 TAGS
+.clang-format

--- a/src/core/include/metaphysicl/ct_types.h
+++ b/src/core/include/metaphysicl/ct_types.h
@@ -29,6 +29,9 @@
 #ifndef METAPHYSICL_CT_TYPES_H
 #define METAPHYSICL_CT_TYPES_H
 
+#include <array>
+#include <vector>
+
 // Compile-time type functions
 
 namespace MetaPhysicL {
@@ -80,6 +83,50 @@ struct FalseType
 {
   typedef bool value_type;
   static const bool value = false;
+};
+
+/**
+ * Structure that can be used for conveniently replacing types in containers. Calling this structure
+ * where the first template argument (T) is a container will result in replacement of the inner
+ * container type with the second structure template argument (U) resulting in a container of U's.
+ * If the first template argument is a nuclear/atomic algebraic type, such as a tensor, vector, or
+ * scalar then the resulting type will simply be U
+ */
+template <typename T, typename U>
+struct ReplaceAlgebraicType;
+
+#define METAPHYSICL_BUILTIN_REPLACE_TYPE(Type)  \
+  template <typename U>                         \
+  struct ReplaceAlgebraicType<Type, U>          \
+  {                                             \
+    typedef U type;                             \
+  }
+
+METAPHYSICL_BUILTIN_REPLACE_TYPE(char);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(signed char);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(unsigned char);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(short int);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(unsigned short int);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(int);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(unsigned int);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(long);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(long long);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(unsigned long);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(unsigned long long);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(float);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(double);
+METAPHYSICL_BUILTIN_REPLACE_TYPE(long double);
+
+template <typename T, typename A, typename U>
+struct ReplaceAlgebraicType<std::vector<T, A>, U>
+{
+  typedef std::vector<U, A> type;
+};
+
+template <typename T, std::size_t N, typename U>
+struct ReplaceAlgebraicType<std::array<T, N>, U>
+{
+  typedef std::array<U, N> type;
 };
 
 } // namespace MetaPhysicL

--- a/src/core/include/metaphysicl/ct_types.h
+++ b/src/core/include/metaphysicl/ct_types.h
@@ -120,13 +120,13 @@ METAPHYSICL_BUILTIN_REPLACE_TYPE(long double);
 template <typename T, typename A, typename U>
 struct ReplaceAlgebraicType<std::vector<T, A>, U>
 {
-  typedef std::vector<U, A> type;
+  typedef std::vector<typename ReplaceAlgebraicType<T, U>::type, A> type;
 };
 
 template <typename T, std::size_t N, typename U>
 struct ReplaceAlgebraicType<std::array<T, N>, U>
 {
-  typedef std::array<U, N> type;
+  typedef std::array<typename ReplaceAlgebraicType<T, U>::type, N> type;
 };
 
 } // namespace MetaPhysicL

--- a/src/numerics/include/metaphysicl/dualnumber_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_decl.h
@@ -37,6 +37,7 @@
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/testable.h"
 #include "metaphysicl/dualnumber_forward.h"
+#include "metaphysicl/ct_types.h"
 
 namespace MetaPhysicL {
 
@@ -325,6 +326,12 @@ struct RawType<DualNumber<T, D, asd> >
   typedef typename RawType<T>::value_type value_type;
 
   static value_type value(const DualNumber<T, D, asd>& a) { return raw_value(a.value()); }
+};
+
+template <typename T, typename D, bool asd, typename U>
+struct ReplaceAlgebraicType<DualNumber<T, D, asd>, U>
+{
+  typedef U type;
 };
 
 template<typename T, typename T2, typename D, bool asd, bool reverseorder>

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberarray_decl.h
@@ -234,6 +234,12 @@ struct ValueType<DynamicSparseNumberArray<T, I> >
   typedef typename ValueType<T>::type type;
 };
 
+template <typename T, typename I, typename U>
+struct ReplaceAlgebraicType<DynamicSparseNumberArray<T, I>, U>
+{
+  typedef DynamicSparseNumberArray<U, I> type;
+};
+
 } // namespace MetaPhysicL
 
 

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberarray_decl.h
@@ -237,7 +237,7 @@ struct ValueType<DynamicSparseNumberArray<T, I> >
 template <typename T, typename I, typename U>
 struct ReplaceAlgebraicType<DynamicSparseNumberArray<T, I>, U>
 {
-  typedef DynamicSparseNumberArray<U, I> type;
+  typedef DynamicSparseNumberArray<typename ReplaceAlgebraicType<T, U>::type, I> type;
 };
 
 } // namespace MetaPhysicL

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberbase_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberbase_decl.h
@@ -40,6 +40,7 @@
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/sparsenumberutils.h"
 #include "metaphysicl/testable.h"
+#include "metaphysicl/ct_types.h"
 
 namespace MetaPhysicL {
 

--- a/src/numerics/include/metaphysicl/dynamicsparsenumbervector_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumbervector_decl.h
@@ -229,6 +229,11 @@ struct ValueType<DynamicSparseNumberVector<T, I> >
   typedef typename ValueType<T>::type type;
 };
 
+template <typename T, typename I, typename U>
+struct ReplaceAlgebraicType<DynamicSparseNumberVector<T, I>, U>
+{
+  typedef U type;
+};
 } // namespace MetaPhysicL
 
 

--- a/src/numerics/include/metaphysicl/numberarray.h
+++ b/src/numerics/include/metaphysicl/numberarray.h
@@ -459,7 +459,7 @@ struct ValueType<NumberArray<N, T> >
 template <std::size_t N, typename T, typename U>
 struct ReplaceAlgebraicType<NumberArray<N, T>, U>
 {
-  typedef NumberArray<N, U> type;
+  typedef NumberArray<N, typename ReplaceAlgebraicType<T, U>::type> type;
 };
 
 } // namespace MetaPhysicL

--- a/src/numerics/include/metaphysicl/numberarray.h
+++ b/src/numerics/include/metaphysicl/numberarray.h
@@ -456,6 +456,12 @@ struct ValueType<NumberArray<N, T> >
   typedef typename ValueType<T>::type type;
 };
 
+template <std::size_t N, typename T, typename U>
+struct ReplaceAlgebraicType<NumberArray<N, T>, U>
+{
+  typedef NumberArray<N, U> type;
+};
+
 } // namespace MetaPhysicL
 
 

--- a/src/numerics/include/metaphysicl/numbervector.h
+++ b/src/numerics/include/metaphysicl/numbervector.h
@@ -455,6 +455,12 @@ struct ValueType<NumberVector<N, T> >
   typedef typename ValueType<T>::type type;
 };
 
+template <std::size_t N, typename T, typename U>
+struct ReplaceAlgebraicType<NumberVector<N, T>, U>
+{
+  typedef U type;
+};
+
 } // namespace MetaPhysicL
 
 

--- a/src/numerics/include/metaphysicl/semidynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/semidynamicsparsenumberarray_decl.h
@@ -141,7 +141,7 @@ struct ValueType<SemiDynamicSparseNumberArray<T, I, N>>
 template <typename T, typename I, typename N, typename U>
 struct ReplaceAlgebraicType<SemiDynamicSparseNumberArray<T, I, N>, U>
 {
-  typedef SemiDynamicSparseNumberArray<U, I, N> type;
+  typedef SemiDynamicSparseNumberArray<typename ReplaceAlgebraicType<T,U>::type, I, N> type;
 };
 } // namespace MetaPhysicL
 

--- a/src/numerics/include/metaphysicl/semidynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/semidynamicsparsenumberarray_decl.h
@@ -138,6 +138,11 @@ struct ValueType<SemiDynamicSparseNumberArray<T, I, N>>
   typedef typename ValueType<T>::type type;
 };
 
+template <typename T, typename I, typename N, typename U>
+struct ReplaceAlgebraicType<SemiDynamicSparseNumberArray<T, I, N>, U>
+{
+  typedef SemiDynamicSparseNumberArray<U, I, N> type;
+};
 } // namespace MetaPhysicL
 
 namespace std

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -31,6 +31,7 @@ check_PROGRAMS += vector_pde_unit
 check_PROGRAMS += parallel_unit
 check_PROGRAMS += pde_unit
 check_PROGRAMS += dynamic_sparse_number_base_unit
+check_PROGRAMS += ct_types_unit
 
 AM_TESTS_ENVIRONMENT =
 if CXX14_ENABLED
@@ -123,6 +124,7 @@ vector_pde_unit_SOURCES += testing.h
 parallel_unit_SOURCES = parallel_unit.C
 pde_unit_SOURCES = pde_unit.C
 pde_unit_SOURCES += testing.h
+ct_types_unit_SOURCES = ct_types_unit.C
 
 #Define tests to actually be run. TESTS is a special automake variable
 TESTS  = run_unit_tests.sh

--- a/test/ct_types_unit.C
+++ b/test/ct_types_unit.C
@@ -1,0 +1,103 @@
+#include <metaphysicl/dynamicsparsenumberarray.h>
+#include <metaphysicl/dynamicsparsenumbervector.h>
+#include <metaphysicl/semidynamicsparsenumberarray.h>
+#include <metaphysicl/numberarray.h>
+#include <metaphysicl/numbervector.h>
+#include <metaphysicl/dualnumber.h>
+
+#define METAPHYSICL_UNIT_ASSERT(expr)                                                              \
+  if (!(expr))                                                                                     \
+  metaphysicl_error()
+
+#ifndef METAPHYSICL_COMMA
+#define METAPHYSICL_COMMA ,
+#endif
+
+using namespace MetaPhysicL;
+
+int
+main()
+{
+  NumberArray<1, float> f_na;
+  DynamicSparseNumberArray<float, unsigned int> f_dsna;
+  SemiDynamicSparseNumberArray<float, unsigned int, NWrapper<1>> f_sdsna;
+  std::array<float, 1> f_a;
+  std::vector<float> f_v;
+
+  NumberArray<1, float> d_na;
+  DynamicSparseNumberArray<float, unsigned int> d_dsna;
+  SemiDynamicSparseNumberArray<float, unsigned int, NWrapper<1>> d_sdsna;
+  std::array<double, 1> d_a;
+  std::vector<double> d_v;
+
+  // Test container replacement
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<decltype(f_na) METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA decltype(d_na)>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<decltype(f_dsna) METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA decltype(d_dsna)>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<decltype(f_sdsna) METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA decltype(d_sdsna)>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<decltype(f_a) METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA decltype(d_a)>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<decltype(f_v) METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA decltype(d_v)>::value);
+
+  // Test atomic/nuclear algebraic type replacement
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<char METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<signed char METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<unsigned char METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<short int METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<unsigned short int METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<int METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<unsigned int METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<long METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<long long METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<unsigned long METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<unsigned long long METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<float METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<long double METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<DualNumber<double> METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(std::is_same<typename ReplaceAlgebraicType<
+                              DynamicSparseNumberVector<double METAPHYSICL_COMMA unsigned int>
+                                  METAPHYSICL_COMMA double>::type METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<
+          NumberVector<1 METAPHYSICL_COMMA double> METAPHYSICL_COMMA double>::type
+                       METAPHYSICL_COMMA double>::value);
+  METAPHYSICL_UNIT_ASSERT(
+      std::is_same<typename ReplaceAlgebraicType<double METAPHYSICL_COMMA float>::type
+                       METAPHYSICL_COMMA float>::value);
+}


### PR DESCRIPTION
Non-trivial "container" implementations for
- std::array
- std::vector
- DynamicSparseNumberArray
- NumberArray
- SemiDynamicSparseNumberArray

And then trivial "atomic" implementations for:
- builtins
- DualNumber
- DynamicSparseNumberVector
- NumberVector
