### PR TITLE
Don't use the same allocator for different types

### DIFF
--- a/src/core/include/metaphysicl/ct_types.h
+++ b/src/core/include/metaphysicl/ct_types.h
@@ -117,10 +117,10 @@ METAPHYSICL_BUILTIN_REPLACE_TYPE(float);
 METAPHYSICL_BUILTIN_REPLACE_TYPE(double);
 METAPHYSICL_BUILTIN_REPLACE_TYPE(long double);
 
-template <typename T, typename A, typename U>
-struct ReplaceAlgebraicType<std::vector<T, A>, U>
+template <typename T, typename U>
+struct ReplaceAlgebraicType<std::vector<T>, U>
 {
-  typedef std::vector<typename ReplaceAlgebraicType<T, U>::type, A> type;
+  typedef std::vector<typename ReplaceAlgebraicType<T, U>::type> type;
 };
 
 template <typename T, std::size_t N, typename U>


### PR DESCRIPTION
Someone will need to explain to me why `std::vector<double, std::allocator<float>>`
compares equal to `std::vector<double, std::allocator<double>>` with
`std::is_same` because `std::vector<VectorValue<double>, std::allocator<double>>`
and `std::vector<VectorValue<double>, std::allocator<VectorValue<double>>>`
sure don't.

I suppose that I could still allow a template argument A to the `struct`, but if someone
has used a non-default allocator, then I'm not sure we want to guess what the new
allocator should be.