### PR TITLE
MPI Reduce support for DualNumber, SemiDynamicSparseNumberArray

### DIFF
--- a/src/numerics/include/metaphysicl/parallel_dualnumber.h
+++ b/src/numerics/include/metaphysicl/parallel_dualnumber.h
@@ -174,15 +174,17 @@ timpi_mpi_metaphysicl_dualnumber_##funcname(void * a, void * b, int * len, MPI_D
 { \
   const int size = *len; \
  \
-  const MetaPhysicL::DualNumber<T,D,asd> * in = \
-    static_cast<MetaPhysicL::DualNumber<T,D,asd> *>(a); \
-  MetaPhysicL::DualNumber<T,D,asd> * inout = \
-    static_cast<MetaPhysicL::DualNumber<T,D,asd> *>(b); \
+  typedef MetaPhysicL::DualNumber<T,D,asd> dtype; \
+ \
+  const dtype * in = \
+    static_cast<dtype *>(a); \
+  dtype * inout = \
+    static_cast<dtype *>(b); \
   for (int i=0; i != size; ++i) \
     { \
       inout[i].value()  = std::funcname<T>()(in[i].value(), inout[i].value()); \
       inout[i].derivatives() = \
-        std::funcname<T>()(in[i].derivatives(),inout[i].derivatives()); \
+        std::funcname<D>()(in[i].derivatives(),inout[i].derivatives()); \
     } \
 }
 

--- a/src/numerics/include/metaphysicl/parallel_dualnumber.h
+++ b/src/numerics/include/metaphysicl/parallel_dualnumber.h
@@ -35,6 +35,7 @@
 #include "metaphysicl/dualnumber.h"
 #include "metaphysicl/metaphysicl_cast.h"
 
+#include "timpi/op_function.h"
 #include "timpi/standard_type.h"
 #include "timpi/packing.h"
 
@@ -121,6 +122,98 @@ class StandardType<DualNumber<T, D, asd>,
 public:
   StandardType(const DualNumber<T, D, asd> *) {}
 };
+
+
+#ifdef TIMPI_HAVE_MPI
+
+# define METAPHYSICL_DUALNUMBER_MPI_BINARY(funcname) \
+static inline void \
+timpi_mpi_metaphysicl_dualnumber_##funcname(void * a, void * b, int * len, MPI_Datatype *) \
+{ \
+  const int size = *len; \
+ \
+  const MetaPhysicL::DualNumber<T,D,asd> * in = \
+    static_cast<MetaPhysicL::DualNumber<T,D,asd> *>(a); \
+  MetaPhysicL::DualNumber<T,D,asd> * inout = \
+    static_cast<MetaPhysicL::DualNumber<T,D,asd> *>(b); \
+  for (int i=0; i != size; ++i) \
+    { \
+      inout[i].value() = std::funcname(in[i].value(),inout[i].value()); \
+      inout[i].derivatives() = \
+        std::funcname(in[i].derivatives(),inout[i].derivatives()); \
+    } \
+}
+
+# define METAPHYSICL_DUALNUMBER_MPI_PAIR_LOCATOR(funcname) \
+static inline void \
+timpi_mpi_metaphysicl_dualnumber_##funcname##_location(void * a, void * b, int * len, MPI_Datatype *) \
+{ \
+  const int size = *len; \
+ \
+  typedef std::pair<MetaPhysicL::DualNumber<T,D,asd>, int> dtype; \
+ \
+  dtype *in = static_cast<dtype*>(a); \
+  dtype *inout = static_cast<dtype*>(b); \
+  for (int i=0; i != size; ++i) \
+    { \
+      MetaPhysicL::DualNumber<T,D,asd> old_inout = inout[i].first; \
+      inout[i].first.value() = \
+        std::funcname(in[i].first.value(), inout[i].first.value()); \
+      inout[i].first.derivatives() = \
+        std::funcname(in[i].first.derivatives(),inout[i].first.derivatives()); \
+      if (old_inout != inout[i].first) \
+        inout[i].second = in[i].second; \
+    } \
+}
+
+
+
+# define METAPHYSICL_DUALNUMBER_MPI_PAIR_BINARY_FUNCTOR(funcname) \
+static inline void \
+timpi_mpi_metaphysicl_dualnumber_##funcname(void * a, void * b, int * len, MPI_Datatype *) \
+{ \
+  const int size = *len; \
+ \
+  const MetaPhysicL::DualNumber<T,D,asd> * in = \
+    static_cast<MetaPhysicL::DualNumber<T,D,asd> *>(a); \
+  MetaPhysicL::DualNumber<T,D,asd> * inout = \
+    static_cast<MetaPhysicL::DualNumber<T,D,asd> *>(b); \
+  for (int i=0; i != size; ++i) \
+    { \
+      inout[i].value()  = std::funcname<T>()(in[i].value(), inout[i].value()); \
+      inout[i].derivatives() = \
+        std::funcname<T>()(in[i].derivatives(),inout[i].derivatives()); \
+    } \
+}
+
+
+  template<typename T, typename D, bool asd>
+  class OpFunction<MetaPhysicL::DualNumber<T,D,asd>>
+  {
+    METAPHYSICL_DUALNUMBER_MPI_BINARY(max)
+    METAPHYSICL_DUALNUMBER_MPI_BINARY(min)
+    METAPHYSICL_DUALNUMBER_MPI_PAIR_LOCATOR(max)
+    METAPHYSICL_DUALNUMBER_MPI_PAIR_LOCATOR(min)
+    METAPHYSICL_DUALNUMBER_MPI_PAIR_BINARY_FUNCTOR(plus)
+    METAPHYSICL_DUALNUMBER_MPI_PAIR_BINARY_FUNCTOR(multiplies)
+
+  public:
+    TIMPI_MPI_OPFUNCTION(max, metaphysicl_dualnumber_max)
+    TIMPI_MPI_OPFUNCTION(min, metaphysicl_dualnumber_min)
+    TIMPI_MPI_OPFUNCTION(sum, metaphysicl_dualnumber_plus)
+    TIMPI_MPI_OPFUNCTION(product, metaphysicl_dualnumber_multiplies)
+
+    TIMPI_MPI_OPFUNCTION(max_location, metaphysicl_dualnumber_max_location)
+    TIMPI_MPI_OPFUNCTION(min_location, metaphysicl_dualnumber_min_location)
+  };
+# else // TIMPI_HAVE_MPI
+  template<typename T, typename U>
+  class OpFunction<MetaPhysicL::DualNumber<T,D,asd>> {};
+#endif
+
+
+
+
 } // namespace TIMPI
 
 namespace libMesh

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -67,11 +67,36 @@ testStandardTypeAssignment()
   a = b;
 }
 
+template <typename D, bool asd>
+void
+testBroadcast()
+{
+  typedef DualNumber<double, D, asd> DualReal;
+
+  const unsigned int my_rank = TestCommWorld->rank();
+
+  // Initialize value
+  DualReal dr = my_rank+4;
+  // Initialize derivative
+  dr.derivatives().insert(my_rank) = (my_rank+1);
+
+  TestCommWorld->broadcast(dr);
+
+  METAPHYSICL_UNIT_ASSERT(dr.value() == 4.0);
+  METAPHYSICL_UNIT_ASSERT(dr.derivatives().size() == 1);
+  METAPHYSICL_UNIT_ASSERT(dr.derivatives()[0] == 1.0);
+}
+
 int
 main(int argc, const char * const * argv)
 {
   TIMPI::TIMPIInit init(argc, argv);
   TestCommWorld = &init.comm();
+
+  testBroadcast<DynamicSparseNumberArray<double, unsigned int>, true>();
+  testBroadcast<DynamicSparseNumberArray<double, unsigned int>, false>();
+  testBroadcast<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, true>();
+  testBroadcast<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, false>();
 
   testContainerAllGather<DynamicSparseNumberArray<double, unsigned int>, true>();
   testContainerAllGather<DynamicSparseNumberArray<double, unsigned int>, false>();

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -87,11 +87,36 @@ testBroadcast()
   METAPHYSICL_UNIT_ASSERT(dr.derivatives()[0] == 1.0);
 }
 
+
+template <typename D, bool asd>
+void
+testDualSum()
+{
+  typedef DualNumber<double, D, asd> DualReal;
+
+  const unsigned int my_rank = TestCommWorld->rank();
+  const unsigned int comm_size = TestCommWorld->size();
+
+  // Initialize value
+  DualReal dr = my_rank+4;
+  // Initialize derivative
+  dr.derivatives() = my_rank+2;
+
+  TestCommWorld->sum(dr);
+
+  METAPHYSICL_UNIT_ASSERT(dr.value() == 4.0*comm_size + comm_size*(comm_size-1)/2);
+  METAPHYSICL_UNIT_ASSERT(dr.derivatives() == 2.0*comm_size + comm_size*(comm_size-1)/2);
+}
+
+
 int
 main(int argc, const char * const * argv)
 {
   TIMPI::TIMPIInit init(argc, argv);
   TestCommWorld = &init.comm();
+
+  testDualSum<double, true>();
+  testDualSum<double, false>();
 
   testBroadcast<DynamicSparseNumberArray<double, unsigned int>, true>();
   testBroadcast<DynamicSparseNumberArray<double, unsigned int>, false>();

--- a/test/parallel_unit.C
+++ b/test/parallel_unit.C
@@ -27,6 +27,8 @@ using namespace MetaPhysicL;
 
 Communicator * TestCommWorld;
 
+constexpr unsigned int maxarraysize = 50;
+
 template <typename D, bool asd>
 void
 testContainerAllGather()
@@ -111,30 +113,61 @@ testDualSum()
 }
 
 
-template <typename D, bool asd>
+template <typename C>
 void
 testContainerSum()
+{
+  const unsigned int my_rank = TestCommWorld->rank();
+  const unsigned int comm_size = TestCommWorld->size();
+  const unsigned int full_size = std::min(maxarraysize-1, comm_size);
+
+  // Initialize values
+  C c;
+  if (my_rank < full_size)
+    {
+      c.insert(my_rank) = (my_rank+1);
+      c.insert(my_rank+1) = (my_rank+2);
+    }
+
+  TestCommWorld->sum(c);
+
+  METAPHYSICL_UNIT_ASSERT(c.size() == full_size+1);
+
+  METAPHYSICL_UNIT_ASSERT(c[0] == 1.0);
+  for (unsigned int p = 1; p != full_size; ++p)
+    METAPHYSICL_UNIT_ASSERT(c[p] == 2*p+2);
+  METAPHYSICL_UNIT_ASSERT(c[full_size] == full_size+1);
+}
+
+
+template <typename D, bool asd>
+void
+testDualContainerSum()
 {
   typedef DualNumber<double, D, asd> DualReal;
 
   const unsigned int my_rank = TestCommWorld->rank();
   const unsigned int comm_size = TestCommWorld->size();
+  const unsigned int full_size = std::min(maxarraysize-1, comm_size);
 
   // Initialize value
   DualReal dr = my_rank+4;
   // Initialize derivative
-  dr.derivatives().insert(my_rank) = (my_rank+1);
-  dr.derivatives().insert(my_rank+1) = (my_rank+2);
+  if (my_rank < full_size)
+    {
+      dr.derivatives().insert(my_rank) = (my_rank+1);
+      dr.derivatives().insert(my_rank+1) = (my_rank+2);
+    }
 
   TestCommWorld->sum(dr);
 
-  METAPHYSICL_UNIT_ASSERT(dr.value() == 4.0*comm_size + comm_size*(comm_size-1)/2);
-  METAPHYSICL_UNIT_ASSERT(dr.derivatives().size() == comm_size+1);
+  METAPHYSICL_UNIT_ASSERT(dr.value() == 4.0*full_size + full_size*(full_size-1)/2);
+  METAPHYSICL_UNIT_ASSERT(dr.derivatives().size() == full_size+1);
 
   METAPHYSICL_UNIT_ASSERT(dr.derivatives()[0] == 1.0);
-  for (unsigned int p = 1; p != comm_size; ++p)
+  for (unsigned int p = 1; p != full_size; ++p)
     METAPHYSICL_UNIT_ASSERT(dr.derivatives()[p] == 2*p+2);
-  METAPHYSICL_UNIT_ASSERT(dr.derivatives()[comm_size] == comm_size+1);
+  METAPHYSICL_UNIT_ASSERT(dr.derivatives()[full_size] == full_size+1);
 }
 
 
@@ -149,24 +182,26 @@ main(int argc, const char * const * argv)
 
   testBroadcast<DynamicSparseNumberArray<double, unsigned int>, true>();
   testBroadcast<DynamicSparseNumberArray<double, unsigned int>, false>();
-  testBroadcast<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, true>();
-  testBroadcast<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, false>();
+  testBroadcast<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>, true>();
+  testBroadcast<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>, false>();
 
   testContainerAllGather<DynamicSparseNumberArray<double, unsigned int>, true>();
   testContainerAllGather<DynamicSparseNumberArray<double, unsigned int>, false>();
-  testContainerAllGather<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, true>();
-  testContainerAllGather<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, false>();
+  testContainerAllGather<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>, true>();
+  testContainerAllGather<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>, false>();
+
+  testContainerSum<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>>();
 
 /*
   // These rely on reduction support for packed-range types!
-  testContainerSum<DynamicSparseNumberArray<double, unsigned int>, true>();
-  testContainerSum<DynamicSparseNumberArray<double, unsigned int>, false>();
+  testDualContainerSum<DynamicSparseNumberArray<double, unsigned int>, true>();
+  testDualContainerSum<DynamicSparseNumberArray<double, unsigned int>, false>();
 */
-  testContainerSum<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, true>();
-  testContainerSum<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>, false>();
+  testDualContainerSum<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>, true>();
+  testDualContainerSum<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>, false>();
 
-  testStandardTypeAssignment<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<50>>>();
-  testStandardTypeAssignment<DynamicStdArrayWrapper<double, NWrapper<50>>>();
+  testStandardTypeAssignment<SemiDynamicSparseNumberArray<double, unsigned int, NWrapper<maxarraysize>>>();
+  testStandardTypeAssignment<DynamicStdArrayWrapper<double, NWrapper<maxarraysize>>>();
   testStandardTypeAssignment<DualNumber<double>>();
 
   return 0;


### PR DESCRIPTION
For any DualNumber instantiation with a StandardType, anyway.

If we want to support custom reductions of true dynamic size datatypes we've got some thinking to do.  We'll basically have to turn everything into packed ranges, and reimplement the whole "logarithmic scaling" magic that MPI does (probably without the "network topology aware" magic...).