### PR TITLE
Add missing headers, inline keywords

### DIFF
--- a/src/numerics/include/metaphysicl/dualnumber_surrogate.h
+++ b/src/numerics/include/metaphysicl/dualnumber_surrogate.h
@@ -3,6 +3,8 @@
 
 #include "metaphysicl/dualnumber_surrogate_decl.h"
 
+#include <utility> // forward
+
 namespace MetaPhysicL
 {
 

--- a/src/numerics/include/metaphysicl/parallel_dualnumber.h
+++ b/src/numerics/include/metaphysicl/parallel_dualnumber.h
@@ -314,7 +314,7 @@ private:
 
 template <typename T, typename D, bool asd>
 template <typename Context>
-unsigned int
+inline unsigned int
 Packing<DualNumber<T, D, asd>,
         typename std::enable_if<!TIMPI::StandardType<DualNumber<T, D, asd>>::is_fixed_type>::type>::
     packable_size(const DualNumber<T, D, asd> & dn, const Context * ctx)
@@ -324,7 +324,7 @@ Packing<DualNumber<T, D, asd>,
 
 template <typename T, typename D, bool asd>
 template <typename BufferIter>
-unsigned int
+inline unsigned int
 Packing<DualNumber<T, D, asd>,
         typename std::enable_if<!TIMPI::StandardType<DualNumber<T, D, asd>>::is_fixed_type>::type>::
     packed_size(BufferIter iter)
@@ -335,7 +335,7 @@ Packing<DualNumber<T, D, asd>,
 
 template <typename T, typename D, bool asd>
 template <typename OutputIter, typename Context>
-void
+inline void
 Packing<DualNumber<T, D, asd>,
         typename std::enable_if<!TIMPI::StandardType<DualNumber<T, D, asd>>::is_fixed_type>::type>::
     pack(const DualNumber<T, D, asd> & dn, OutputIter data_out, const Context * ctx)
@@ -358,7 +358,7 @@ Packing<DualNumber<T, D, asd>,
 
 template <typename T, typename D, bool asd>
 template <typename BufferIter, typename Context>
-DualNumber<T, D, asd>
+inline DualNumber<T, D, asd>
 Packing<DualNumber<T, D, asd>,
         typename std::enable_if<!TIMPI::StandardType<DualNumber<T, D, asd>>::is_fixed_type>::type>::
     unpack(BufferIter in, Context * ctx)

--- a/src/numerics/include/metaphysicl/parallel_dynamicsparsenumberarray.h
+++ b/src/numerics/include/metaphysicl/parallel_dynamicsparsenumberarray.h
@@ -93,7 +93,7 @@ public:
 
 template <typename T, typename I>
 template <typename Context>
-unsigned int
+inline unsigned int
 Packing<DynamicSparseNumberArray<T, I>>::
 packable_size(const DynamicSparseNumberArray<T, I> & dsna,
               const Context *)
@@ -106,7 +106,7 @@ packable_size(const DynamicSparseNumberArray<T, I> & dsna,
 
 template <typename T, typename I>
 template <typename BufferIter>
-unsigned int
+inline unsigned int
 Packing<DynamicSparseNumberArray<T, I>>::
 packed_size(BufferIter iter)
 {
@@ -116,7 +116,7 @@ packed_size(BufferIter iter)
 
 template <typename T, typename I>
 template <typename OutputIter, typename Context>
-void
+inline void
 Packing<DynamicSparseNumberArray<T, I>>::
 pack(const DynamicSparseNumberArray<T, I> & dsna,
      OutputIter data_out,
@@ -146,7 +146,7 @@ pack(const DynamicSparseNumberArray<T, I> & dsna,
 
 template <typename T, typename I>
 template <typename BufferIter, typename Context>
-DynamicSparseNumberArray<T, I>
+inline DynamicSparseNumberArray<T, I>
 Packing<DynamicSparseNumberArray<T, I>>::
 unpack(BufferIter in, Context *)
 {

--- a/src/numerics/include/metaphysicl/parallel_numberarray.h
+++ b/src/numerics/include/metaphysicl/parallel_numberarray.h
@@ -29,6 +29,8 @@
 #ifdef METAPHYSICL_HAVE_TIMPI
 
 #include "metaphysicl/numberarray.h"
+
+#include "timpi/op_function.h"
 #include "timpi/standard_type.h"
 
 namespace TIMPI

--- a/src/numerics/include/metaphysicl/parallel_semidynamicsparsenumberarray.h
+++ b/src/numerics/include/metaphysicl/parallel_semidynamicsparsenumberarray.h
@@ -30,6 +30,8 @@
 
 #include "metaphysicl/semidynamicsparsenumberarray.h"
 #include "metaphysicl/parallel_dynamic_std_array_wrapper.h"
+
+#include "timpi/op_function.h"
 #include "timpi/standard_type.h"
 
 namespace TIMPI

--- a/src/numerics/include/metaphysicl/sparsenumberstruct.h
+++ b/src/numerics/include/metaphysicl/sparsenumberstruct.h
@@ -29,15 +29,16 @@
 #ifndef METAPHYSICL_SPARSENUMBERSTRUCT_H
 #define METAPHYSICL_SPARSENUMBERSTRUCT_H
 
-#include <algorithm>
-#include <functional>
-#include <stdexcept>
-#include <ostream>
-
 #include "metaphysicl/compare_types.h"
 #include "metaphysicl/ct_set.h"
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/testable.h"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+#include <ostream>
+#include <stdexcept>
 
 // We now depend on std::function and kin
 #if __cplusplus >= 201103L

--- a/src/numerics/include/metaphysicl/sparsenumberstruct.h
+++ b/src/numerics/include/metaphysicl/sparsenumberstruct.h
@@ -1148,6 +1148,7 @@ using MetaPhysicL::SparseNumberStruct;
 using MetaPhysicL::BinaryFunctor;
 using MetaPhysicL::UnaryFunctor;
 using MetaPhysicL::ConstantDataSet;
+using MetaPhysicL::CompareTypes;
 
 #define SparseNumberStruct_std_unary(funcname) \
 \


### PR DESCRIPTION
I had been hoping that clang-tidy would help me catch any and every instance of inline-functions-not-marked-so, but I couldn't get https://clang.llvm.org/extra/clang-tidy/checks/misc-definitions-in-headers.html to work for me, so here's a PR with the instances I could find by hand all fixed along with a couple other things that clang-tidy warned about while I was wrestling with it.