### PR TITLE
Disable rvalue references with clang 10 or older

### DIFF
--- a/src/core/include/metaphysicl/metaphysicl_common.h
+++ b/src/core/include/metaphysicl/metaphysicl_common.h
@@ -9,4 +9,31 @@
 #define metaphysicl_dbg_var(var)
 #endif
 
+// If we have C++11, we'd like to define as many operators and
+// functions as possible with rvalue reference parameters, so as to
+// optimize heap access.
+#if __cplusplus >= 201103L
+
+// But if we have e.g. clang 9, then we've seen SIGFPE triggered when
+// using optimizations on rvalue references, in code that raises no
+// warnings and no valgrind errors from -O0, or from any configuration
+// of five other compilers ... so we're just going to make things as
+// easy on clang as possible, and if we want more optimized code we're
+// going to want a better compiler.
+//
+// I don't have clang++-10 handy to check with, so I'm not going to
+// trust it either.
+#ifndef __clang__
+#define METAPHYSICL_USE_STD_MOVE 1
+#else
+#  if __clang_major__ > 10
+#  define METAPHYSICL_USE_STD_MOVE 1
+#  else
+#  undef METAPHYSICL_USE_STD_MOVE
+#  endif
+
+#endif
+
+#endif
+
 #endif // METAPHYSICL_COMMON_H

--- a/src/numerics/include/metaphysicl/dualnumber.h
+++ b/src/numerics/include/metaphysicl/dualnumber.h
@@ -30,7 +30,9 @@
 #define METAPHYSICL_DUALNUMBER_H
 
 #include "metaphysicl/dualnumber_decl.h"
+
 #include "metaphysicl/dualnumber_surrogate.h"
+#include "metaphysicl/metaphysicl_common.h"
 
 namespace MetaPhysicL {
 
@@ -104,6 +106,7 @@ DualNumber<T,D,asd>::operator=(const DualNumber<T,D,asd> & dn)
   return *this;
 }
 
+#ifdef METAPHYSICL_USE_STD_MOVE
 template <typename T, typename D, bool asd>
 inline
 DualNumber<T,D,asd> &
@@ -116,6 +119,7 @@ DualNumber<T,D,asd>::operator=(DualNumber<T,D,asd> && dn)
 
   return *this;
 }
+#endif // METAPHYSICL_USE_STD_MOVE
 
 template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
@@ -140,6 +144,7 @@ DualNumber<T,D,asd>::DualNumber(const DualNumber<T,D,asd> & dn) :
     _deriv = dn.derivatives();
 }
 
+#ifdef METAPHYSICL_USE_STD_MOVE
 template <typename T, typename D, bool asd>
 inline
 DualNumber<T,D,asd>::DualNumber(DualNumber<T,D,asd> && dn) :
@@ -148,6 +153,7 @@ DualNumber<T,D,asd>::DualNumber(DualNumber<T,D,asd> && dn) :
   if (!allow_skipping_derivatives || do_derivatives)
     _deriv = std::move(dn.derivatives());
 }
+#endif // METAPHYSICL_USE_STD_MOVE
 
 template <typename T, typename D, bool asd>
 template <typename T2, typename D2>
@@ -427,7 +433,7 @@ operator opname (const DualNumber<T,D,asd>& a, const T2& b) \
 // more complete and define the move-from-b alternatives as well, but
 // those would require additional support to correctly handle
 // division, subtraction, or non-commutative addition/multiplication
-#if __cplusplus >= 201103L
+#ifdef METAPHYSICL_USE_STD_MOVE
 #define DualNumber_op(opname, functorname, simplecalc, dualcalc) \
         DualNumber_preop(opname, functorname, simplecalc, dualcalc) \
  \
@@ -553,7 +559,7 @@ inline bool isinf (const DualNumber<T,D,asd> & a)
 }
 
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 #define DualNumber_std_unary(funcname, derivative, precalc) \
 template <typename T, typename D, bool asd> \
 inline \
@@ -736,7 +742,7 @@ funcname(const DualNumber<std::complex<T>,std::complex<T>,asd> & in) \
                                                      std::numeric_limits<double>::quiet_NaN()}}; \
 }
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 #define DualNumber_complex_std_unary_complex(funcname) \
 DualNumber_complex_std_unary_complex_pre(funcname) \
 template <typename T, typename D, bool asd> \

--- a/src/numerics/include/metaphysicl/dualnumber_decl.h
+++ b/src/numerics/include/metaphysicl/dualnumber_decl.h
@@ -29,15 +29,17 @@
 #ifndef METAPHYSICL_DUALNUMBER_DECL_H
 #define METAPHYSICL_DUALNUMBER_DECL_H
 
-#include <ostream>
-#include <limits>
+#include "metaphysicl/dualnumber_forward.h"
 
 #include "metaphysicl/compare_types.h"
+#include "metaphysicl/ct_types.h"
 #include "metaphysicl/dualderivatives.h"
+#include "metaphysicl/metaphysicl_common.h"
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/testable.h"
-#include "metaphysicl/dualnumber_forward.h"
-#include "metaphysicl/ct_types.h"
+
+#include <limits>
+#include <ostream>
 
 namespace MetaPhysicL {
 
@@ -75,19 +77,21 @@ public:
   template <typename T2, typename D2>
   DualNumber(const T2& val, const D2& deriv);
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
   // Move constructors are useful when all your data is on the heap
   DualNumber(DualNumber<T, D, asd> && /*src*/);
 
   // Move assignment avoids heap operations too
   DualNumber& operator= (DualNumber<T, D, asd> && /*src*/);
+#endif
 
   // Standard copy operations get implicitly deleted upon move
-  // constructor definition, so we redefine them.
+  // constructor definition, so we'd need to redefine them.  We'll
+  // redefine them in non-move builds too, so we can skip derivative
+  // assignment in the !asd case.
   DualNumber(const DualNumber<T, D, asd> & /*src*/);
 
   DualNumber& operator= (const DualNumber<T, D, asd> & /*src*/);
-#endif
 
   template <typename T2, typename D2>
   DualNumber & operator=(const DualNumber<T2,D2,asd> & dn);
@@ -248,7 +252,7 @@ operator opname (const DualNumber<T,D,asd>& a, const T2& b);
 // more complete and define the move-from-b alternatives as well, but
 // those would require additional support to correctly handle
 // division, subtraction, or non-commutative addition/multiplication
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 #define DualNumber_decl_op(opname, functorname) \
         DualNumber_decl_preop(opname, functorname) \
  \
@@ -541,7 +545,7 @@ inline bool isinf (const DualNumber<T,D,asd> & a);
 
 // Some forward declarations necessary for recursive DualNumbers
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 
 template <typename T, typename D, bool asd>
 inline DualNumber<T,D,asd> cos  (const DualNumber<T,D,asd> & a);
@@ -567,7 +571,7 @@ inline DualNumber<T,D,asd> cosh (DualNumber<T,D,asd> a);
 
 // Now just combined declaration/definitions
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 #define DualNumber_decl_std_unary(funcname) \
 template <typename T, typename D, bool asd> \
 inline \
@@ -671,7 +675,7 @@ template <typename T, bool asd> \
 inline DualNumber<std::complex<T>,std::complex<T>,asd> \
 funcname(const DualNumber<std::complex<T>,std::complex<T>,asd> & in)
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 #define DualNumber_decl_complex_std_unary_complex(funcname) \
 DualNumber_decl_complex_std_unary_complex_pre(funcname);  \
 template <typename T, typename D, bool asd> \
@@ -684,7 +688,7 @@ funcname(DualNumber<std::complex<T>,std::complex<T>,asd> && in)
 
 #else
 #define DualNumber_decl_complex_std_unary_complex(funcname) \
-DualNumber_complex_std_unary_complex_pre(funcname);
+DualNumber_decl_complex_std_unary_complex_pre(funcname);
 #endif
 
 DualNumber_decl_complex_std_unary_complex(conj);

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberarray.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberarray.h
@@ -63,17 +63,21 @@ DynamicSparseNumberArray<T,I>::DynamicSparseNumberArray(const T2& val) {
 #endif
 }
 
+
 template <typename T, typename I>
 template <typename T2, typename I2>
 inline
 DynamicSparseNumberArray<T,I>::DynamicSparseNumberArray(const DynamicSparseNumberArray<T2, I2> & src) :
     DynamicSparseNumberBase<std::vector<T>,std::vector<I>,MetaPhysicL::DynamicSparseNumberArray,T,I>(src) {}
 
+
+#ifdef METAPHYSICL_USE_STD_MOVE
 template <typename T, typename I>
 template <typename T2, typename I2>
 inline
 DynamicSparseNumberArray<T,I>::DynamicSparseNumberArray(DynamicSparseNumberArray<T2, I2> && src) :
     DynamicSparseNumberBase<std::vector<T>,std::vector<I>,MetaPhysicL::DynamicSparseNumberArray,T,I>(src) {}
+#endif
 
 
 template <typename T, typename I>

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberarray_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberarray_decl.h
@@ -29,9 +29,11 @@
 #ifndef METAPHYSICL_DYNAMICSPARSENUMBERARRAY_DECL_H
 #define METAPHYSICL_DYNAMICSPARSENUMBERARRAY_DECL_H
 
-#include <vector>
-
 #include "metaphysicl/dynamicsparsenumberbase_decl.h"
+
+#include "metaphysicl/metaphysicl_common.h"
+
+#include <vector>
 
 namespace MetaPhysicL {
 
@@ -88,7 +90,7 @@ public:
   template <typename T2>
   DynamicSparseNumberArray(const T2& val);
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
   // Move constructors are useful when all your data is on the heap
   DynamicSparseNumberArray(DynamicSparseNumberArray<T, I> && src) = default;
 
@@ -100,13 +102,13 @@ public:
   DynamicSparseNumberArray(const DynamicSparseNumberArray<T, I> & src) = default;
 
   DynamicSparseNumberArray& operator= (const DynamicSparseNumberArray<T, I> & src) = default;
+
+  template <typename T2, typename I2>
+  DynamicSparseNumberArray(DynamicSparseNumberArray<T2, I2> && src);
 #endif
 
   template <typename T2, typename I2>
   DynamicSparseNumberArray(const DynamicSparseNumberArray<T2, I2> & src);
-
-  template <typename T2, typename I2>
-  DynamicSparseNumberArray(DynamicSparseNumberArray<T2, I2> && src);
 
   template <typename T2, typename I2>
   DynamicSparseNumberArray

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberbase.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberbase.h
@@ -31,6 +31,8 @@
 
 #include "metaphysicl/dynamicsparsenumberbase_decl.h"
 
+#include "metaphysicl/metaphysicl_common.h"
+
 namespace MetaPhysicL {
 
 template <typename Data, typename Indices, template <class...> class SubType, class... SubTypeArgs>
@@ -61,6 +63,7 @@ DynamicSparseNumberBase(const DynamicSparseNumberBase<Data2, Indices2, SubType, 
   std::copy(src.nude_data().begin(), src.nude_data().end(), _data.begin());
   std::copy(src.nude_indices().begin(), src.nude_indices().end(), _indices.begin()); }
 
+#ifdef METAPHYSICL_USE_STD_MOVE
 template <typename Data, typename Indices, template <class...> class SubType, class... SubTypeArgs>
 template <typename Data2, typename Indices2, class... SubTypeArgs2>
 inline DynamicSparseNumberBase<Data, Indices, SubType, SubTypeArgs...>::DynamicSparseNumberBase(
@@ -69,6 +72,7 @@ inline DynamicSparseNumberBase<Data, Indices, SubType, SubTypeArgs...>::DynamicS
   _data = std::move(src.nude_data());
   _indices = std::move(src.nude_indices());
 }
+#endif // METAPHYSICL_USE_STD_MOVE
 
 template <typename Data, typename Indices, template <class...> class SubType, class... SubTypeArgs>
 inline
@@ -912,7 +916,7 @@ operator opname (const subtypename<AArgs...> & a, const subtypename<BArgs...> & 
 }
 
 
-#if __cplusplus >= 201103L
+#ifdef METAPHYSICL_USE_STD_MOVE
 
 #define DynamicSparseNumberBase_op(subtypename, opname, functorname) \
 DynamicSparseNumberBase_op_ab(opname, subtypename, functorname) \

--- a/src/numerics/include/metaphysicl/dynamicsparsenumberbase_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumberbase_decl.h
@@ -29,18 +29,19 @@
 #ifndef METAPHYSICL_DYNAMICSPARSENUMBERBASE_DECL_H
 #define METAPHYSICL_DYNAMICSPARSENUMBERBASE_DECL_H
 
-#include <algorithm>
-#include <functional>
-#include <stdexcept>
-#include <ostream>
-
 #include "metaphysicl/compare_types.h"
 #include "metaphysicl/ct_set.h"
+#include "metaphysicl/ct_types.h"
 #include "metaphysicl/metaphysicl_asserts.h"
+#include "metaphysicl/metaphysicl_common.h"
 #include "metaphysicl/raw_type.h"
 #include "metaphysicl/sparsenumberutils.h"
 #include "metaphysicl/testable.h"
-#include "metaphysicl/ct_types.h"
+
+#include <algorithm>
+#include <functional>
+#include <ostream>
+#include <stdexcept>
 
 namespace MetaPhysicL {
 
@@ -66,7 +67,7 @@ public:
 
   DynamicSparseNumberBase();
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
   // Move constructors are useful when all your data is on the heap
   DynamicSparseNumberBase(DynamicSparseNumberBase && src) = default;
 
@@ -78,15 +79,15 @@ public:
   DynamicSparseNumberBase(const DynamicSparseNumberBase & src) = default;
 
   DynamicSparseNumberBase& operator= (const DynamicSparseNumberBase & src) = default;
+
+  template <typename Data2, typename Indices2, class... SubTypeArgs2>
+  DynamicSparseNumberBase(
+      DynamicSparseNumberBase<Data2, Indices2, SubType, SubTypeArgs2...> && src);
 #endif
 
   template <typename Data2, typename Indices2, class... SubTypeArgs2>
   DynamicSparseNumberBase(
       const DynamicSparseNumberBase<Data2, Indices2, SubType, SubTypeArgs2...> & src);
-
-  template <typename Data2, typename Indices2, class... SubTypeArgs2>
-  DynamicSparseNumberBase(
-      DynamicSparseNumberBase<Data2, Indices2, SubType, SubTypeArgs2...> && src);
 
   T* raw_data();
 
@@ -212,7 +213,7 @@ inline typename Symmetric##functorname##Type<subtypename<AArgs...>, \
 operator opname(const subtypename<AArgs...> & a, const subtypename<BArgs...> & b);
 
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 
 #define DynamicSparseNumberBase_decl_op(subtypename, opname, functorname) \
 DynamicSparseNumberBase_decl_op_ab(opname, subtypename, functorname) \
@@ -259,7 +260,7 @@ inline typename DividesType<SubType<SubTypeArgs...>, T>::supertype
 operator/(const DynamicSparseNumberBase<Data, Indices, SubType, SubTypeArgs...> & a,
           const T & b);
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
 
 template <template <class...> class SubType,
           typename Data,

--- a/src/numerics/include/metaphysicl/dynamicsparsenumbervector.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumbervector.h
@@ -66,11 +66,14 @@ inline
 DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(const DynamicSparseNumberVector<T2, I2> & src) :
     DynamicSparseNumberBase<std::vector<T>,std::vector<I>,MetaPhysicL::DynamicSparseNumberVector,T,I>(src) {}
 
+
+#ifdef METAPHYSICL_USE_STD_MOVE
 template <typename T, typename I>
 template <typename T2, typename I2>
 inline
 DynamicSparseNumberVector<T,I>::DynamicSparseNumberVector(DynamicSparseNumberVector<T2, I2> && src) :
   DynamicSparseNumberBase<std::vector<T>,std::vector<I>,MetaPhysicL::DynamicSparseNumberVector,T,I>(src) {}
+#endif
 
 
 template <typename T, typename I>

--- a/src/numerics/include/metaphysicl/dynamicsparsenumbervector_decl.h
+++ b/src/numerics/include/metaphysicl/dynamicsparsenumbervector_decl.h
@@ -29,9 +29,11 @@
 #ifndef METAPHYSICL_DYNAMICSPARSENUMBERVECTOR_DECL_H
 #define METAPHYSICL_DYNAMICSPARSENUMBERVECTOR_DECL_H
 
-#include <vector>
-
 #include "metaphysicl/dynamicsparsenumberbase_decl.h"
+
+#include "metaphysicl/metaphysicl_common.h"
+
+#include <vector>
 
 namespace MetaPhysicL {
 
@@ -82,7 +84,7 @@ public:
   template <typename T2>
   DynamicSparseNumberVector(const T2& val);
 
-#if __cplusplus >= 201103L
+#if METAPHYSICL_USE_STD_MOVE
   // Move constructors are useful when all your data is on the heap
   DynamicSparseNumberVector(DynamicSparseNumberVector<T, I> && src) = default;
 
@@ -94,13 +96,13 @@ public:
   DynamicSparseNumberVector(const DynamicSparseNumberVector<T, I> & src) = default;
 
   DynamicSparseNumberVector& operator= (const DynamicSparseNumberVector<T, I> & src) = default;
+
+  template <typename T2, typename I2>
+  DynamicSparseNumberVector(DynamicSparseNumberVector<T2, I2> && src);
 #endif
 
   template <typename T2, typename I2>
   DynamicSparseNumberVector(const DynamicSparseNumberVector<T2, I2> & src);
-
-  template <typename T2, typename I2>
-  DynamicSparseNumberVector(DynamicSparseNumberVector<T2, I2> && src);
 
   template <typename T2, typename I2>
   typename MultipliesType<T,T2>::supertype


### PR DESCRIPTION
This fixes the issues I was raving about in #16, on my system at least.