### PR TITLE
--with-future-timpi-dir support fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -143,11 +143,11 @@ AS_IF([test "$enable_installed_timpi" = yes],
         HAVE_TIMPI_LIB=1
         AC_DEFINE(HAVE_TIMPI,1,[Define if TIMPI headers are available])
         AC_DEFINE(HAVE_TIMPI_LIB,1,[Define if a TIMPI library is available])
-        TIMPI_CPPFLAGS="-I$TIMPI_PREFIX/include $TIMPI_CPPFLAGS"
+        TIMPI_CPPFLAGS=""
 
         dnl We don't know what METHODS a not-yet-installed TIMPI was
         dnl built with; let's guess opt?
-        TIMPI_LIBS="-L$TIMPI_PREFIX/lib -ltimpi_$timpi_method $TIMPI_LIBS"
+        TIMPI_LIBS=""
       ],
       [])
 

--- a/configure.ac
+++ b/configure.ac
@@ -145,9 +145,7 @@ AS_IF([test "$enable_installed_timpi" = yes],
         AC_DEFINE(HAVE_TIMPI_LIB,1,[Define if a TIMPI library is available])
         TIMPI_CPPFLAGS=""
 
-        dnl We don't know what METHODS a not-yet-installed TIMPI was
-        dnl built with; let's guess opt?
-        TIMPI_LIBS=""
+        TIMPI_LIBS="-ltimpi_$timpi_method"
       ],
       [])
 


### PR DESCRIPTION
This seems to be sufficient for me (along with changes on the libMesh side) to work around the configuration issues we're seeing with the latest MetaPhysicL update there.  Not manually putting a may-not-yet-be-installed prefix into the compiler line prevents compiler warnings from screaming.