### PR TITLE
Fix "TIMPI enabled, but MPI disabled" builds

### DIFF
--- a/src/numerics/include/metaphysicl/parallel_dualnumber.h
+++ b/src/numerics/include/metaphysicl/parallel_dualnumber.h
@@ -98,7 +98,7 @@ public:
 #endif // TIMPI_HAVE_MPI
   }
 
-  StandardType(const StandardType<DualNumber<T, D, asd>> & timpi_mpi_var(t)) :
+  StandardType(const StandardType<DualNumber<T, D, asd>> & t) :
     DataType(t._datatype) {}
 
   StandardType & operator=(StandardType & t)
@@ -207,7 +207,7 @@ timpi_mpi_metaphysicl_dualnumber_##funcname(void * a, void * b, int * len, MPI_D
     TIMPI_MPI_OPFUNCTION(min_location, metaphysicl_dualnumber_min_location)
   };
 # else // TIMPI_HAVE_MPI
-  template<typename T, typename U>
+  template<typename T, typename D, bool asd>
   class OpFunction<MetaPhysicL::DualNumber<T,D,asd>> {};
 #endif
 

--- a/src/numerics/include/metaphysicl/parallel_numberarray.h
+++ b/src/numerics/include/metaphysicl/parallel_numberarray.h
@@ -90,11 +90,8 @@ public:
 #endif // TIMPI_HAVE_MPI
   }
 
-  StandardType(
-      const StandardType<MetaPhysicL::NumberArray<N, T>> & timpi_mpi_var(t))
-  {
-    _datatype = t._datatype;
-  }
+  StandardType(const StandardType & t) :
+    DataType(t._datatype) {}
 
   StandardType & operator=(StandardType & t)
   {
@@ -166,7 +163,7 @@ timpi_mpi_metaphysicl_na_##funcname(void * a, void * b, int * len, MPI_Datatype 
     // TIMPI_MPI_OPFUNCTION(min_location, metaphysicl_na_min_location)
   };
 # else // TIMPI_HAVE_MPI
-  template<typename T, typename U>
+  template<std::size_t N, typename T>
   class OpFunction<MetaPhysicL::NumberArray<N,T>> {};
 #endif
 

--- a/src/numerics/include/metaphysicl/parallel_semidynamicsparsenumberarray.h
+++ b/src/numerics/include/metaphysicl/parallel_semidynamicsparsenumberarray.h
@@ -91,11 +91,8 @@ public:
 #endif // TIMPI_HAVE_MPI
   }
 
-  StandardType(
-      const StandardType<MetaPhysicL::SemiDynamicSparseNumberArray<T, I, N>> & timpi_mpi_var(t))
-  {
-    _datatype = t._datatype;
-  }
+  StandardType(const StandardType & t) :
+    DataType(t._datatype) {}
 
   StandardType & operator=(StandardType & t)
   {
@@ -167,7 +164,7 @@ timpi_mpi_metaphysicl_sdsna_##funcname(void * a, void * b, int * len, MPI_Dataty
     // TIMPI_MPI_OPFUNCTION(min_location, metaphysicl_sdsna_min_location)
   };
 # else // TIMPI_HAVE_MPI
-  template<typename T, typename U>
+  template<typename T, typename I, typename N>
   class OpFunction<MetaPhysicL::SemiDynamicSparseNumberArray<T,I,N>> {};
 #endif
 

--- a/src/utilities/include/metaphysicl/parallel_dynamic_std_array_wrapper.h
+++ b/src/utilities/include/metaphysicl/parallel_dynamic_std_array_wrapper.h
@@ -84,10 +84,8 @@ public:
 #endif // TIMPI_HAVE_MPI
   }
 
-  StandardType(const StandardType<MetaPhysicL::DynamicStdArrayWrapper<T, NType>> & timpi_mpi_var(t))
-  {
-    _datatype = t._datatype;
-  }
+  StandardType(const StandardType & t) :
+    DataType(t._datatype) {}
 
   StandardType & operator=(StandardType & t)
   {


### PR DESCRIPTION
We need to get more direct testing for these too, but at least libMesh will be testing them during devel->master merges now.