### PR TITLE
Eliminate code that was deprecated in C++17

### DIFF
--- a/src/graphs/include/metaphysicl/physics.h
+++ b/src/graphs/include/metaphysicl/physics.h
@@ -84,7 +84,7 @@ struct UnaryPhysics
 {
   template <typename inputtype, typename outputtype>
   struct as_unary_function :
-    public std::unary_function<inputtype, outputtype>
+    public std::function<outputtype(inputtype)>
   {
     outputtype operator() (const inputtype& in)
     {
@@ -101,7 +101,7 @@ struct BinaryPhysics
 {
   template <typename input1type, typename input2type, typename outputtype>
   struct as_binary_function :
-    public std::binary_function<input1type, input2type, outputtype>
+    public std::function<outputtype(input1type, input2type)>
   {
     outputtype operator()
       (const input1type& in1, const input2type& in2) 


### PR DESCRIPTION
std::bind1st/bind2nd, std::unary/binary_function, and some others, were all deprecated in C++11 by variadic templates, and were eventually removed entirely from C++17.  We got rid of the ones used by libMesh but missed an internal one.