### PR TITLE
Avoid and test for spurious FPEs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,7 +85,14 @@ AM_CONDITIONAL(CXX14_ENABLED,test x$HAVE_CXX14 = x1)
 
 AM_CONDITIONAL(CXX11_ENABLED,test x$HAVE_CXX11 = x1)
 
+dnl Get CXXFLAGS and optional flags for this compiler
 ACSM_SET_CXX_FLAGS
+
+dnl Make sure it's safe to turn on FP exceptions
+ACSM_SET_FPE_SAFETY_FLAGS
+
+dnl provide the resulting flags to our Makefiles
+AC_SUBST(ACSM_CXXFLAGS_OPT)
 
 dnl Workaround for ACSM bug
 WERROR_FLAGS="$ACSM_WERROR_FLAGS"
@@ -99,7 +106,7 @@ ACSM_ENABLE_PARANOID
 dnl And those tests should fail, not just whine
 ACSM_ENABLE_WERROR
 
-dnl See if we can turn on FP exceptions
+dnl See if we *can* turn on FP exceptions
 AC_HAVE_FEEXCEPT
 
 LT_INIT

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -22,7 +22,7 @@ echo
 echo Package version............... : $PACKAGE-$VERSION
 echo
 echo C++ compiler.................. : $CXX
-echo C++ compiler flags............ : $CXXFLAGS
+echo C++ compiler flags............ : $ACSM_CXXFLAGS_OPT
 AS_ECHO(["Any warnings-to-errors flags....... : $ACSM_ANY_WERROR_FLAG"])
 AS_ECHO(["Any extra paranoid warning flags... : $ACSM_ANY_PARANOID_FLAGS"])
 echo Install dir................... : $prefix

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -110,7 +110,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/numerics/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/utilities/include
 AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #metaphysicl_version.h
 
-AM_CXXFLAGS = $(ACSM_ANY_WERROR_FLAG) $(ACSM_ANY_PARANOID_FLAGS)
+AM_CXXFLAGS = $(ACSM_CXXFLAGS_OPT) $(ACSM_ANY_WERROR_FLAG) $(ACSM_ANY_PARANOID_FLAGS)
 
 CLEANFILES =
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,5 @@
 check_PROGRAMS  =
+check_PROGRAMS += avoid_spurious_fpe_unit # first, to avoid confusion later
 check_PROGRAMS += compare_types_unit
 check_PROGRAMS += derivs_unit
 check_PROGRAMS += nd_derivs_unit
@@ -57,6 +58,7 @@ AM_CXXFLAGS = $(ACSM_ANY_WERROR_FLAG) $(ACSM_ANY_PARANOID_FLAGS)
 AM_LDFLAGS = $(top_builddir)/src/libmetaphysicl.la
 
 # Sources for these tests
+avoid_spurious_fpe_unit_SOURCES = avoid_spurious_fpe_unit.C
 compare_types_unit_SOURCES = compare_types_unit.C
 derivs_unit_SOURCES = derivs_unit.C
 nd_derivs_unit_SOURCES = nd_derivs_unit.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -53,7 +53,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/numerics/include
 AM_CPPFLAGS += -I$(top_srcdir)/src/utilities/include
 AM_CPPFLAGS += -I$(top_builddir)/src/utilities/include #metaphysicl_version.h, metaphysicl_config.h
 
-AM_CXXFLAGS = $(ACSM_ANY_WERROR_FLAG) $(ACSM_ANY_PARANOID_FLAGS)
+AM_CXXFLAGS = $(ACSM_CXXFLAGS_OPT) $(ACSM_ANY_WERROR_FLAG) $(ACSM_ANY_PARANOID_FLAGS)
 
 AM_LDFLAGS = $(top_builddir)/src/libmetaphysicl.la
 

--- a/test/avoid_spurious_fpe_unit.C
+++ b/test/avoid_spurious_fpe_unit.C
@@ -1,0 +1,73 @@
+// clang++ (16.0.6 or 15.0.7) -O2 gives a SIGFPE when running this
+// clang++ -O1, -O0, or -O3 give no SIGFPE
+// clang++ 14.0.6 or 13.0.1 give no SIGFPE
+// clang++ -fsanitize=undefined,address -O2 gives no warnings and no SIGFPE!
+
+#include <iostream>
+
+// Most of this test is library-free, just aimed at testing the
+// compiler, but we need to make sure we're not using feenableexcept()
+// unless we detected it, so we need MetaPhysicL::enableFPE()
+#include "metaphysicl/metaphysicl_exceptions.h"
+
+template <typename T, typename D>
+struct DualNumber
+{
+  DualNumber () : val(0), deriv(0) {}
+
+  template <typename T2, typename D2>
+  DualNumber (DualNumber<T2,D2>& a) :
+    val(a.val), deriv(a.deriv) {}
+
+  T val;
+  D deriv;
+};
+
+
+template <std::size_t N, typename T>
+struct NumberArray
+{
+  NumberArray (T a)
+    { for (std::size_t i=0; i != N; ++i) _data[i] = a; }
+
+  // Access a[i] via a._data[i] and no more SIGFPE!
+  template <typename T2>
+  NumberArray (NumberArray<N,T2>& a)
+    { for (std::size_t i=0; i != N; ++i) _data[i] = a[i]; }
+
+  T& operator[](std::size_t i)
+    {
+      // Remove this assert, even just std::endl, and no more SIGFPE!
+      if (!(i < N)) { std::cerr << "Assert failed." << std::endl; }
+      return _data[i]; }
+
+  NumberArray<N,T>& operator/= (const T& a)
+    { for (std::size_t i=0; i != N; ++i) _data[i] /= a; return *this; }
+
+  T _data[N];
+};
+
+
+static const unsigned int N = 9; // 9 or 10 SIGFPEs
+// static const unsigned int N = 8; // 8 or fewer doesn't SIGFPE
+
+int main(int, char *[])
+{
+  MetaPhysicL::enableFPE(true);
+
+  typedef float Scalar;  // double doesn't SIGFPE!
+  DualNumber<Scalar, NumberArray<N, Scalar>> dn;
+
+  // No copy made, no SIGFPE!
+  DualNumber<Scalar, NumberArray<N, Scalar>> dncopy{dn};
+
+  // Changing only one member doesn't SIGFPE!
+  // 2 (or 2.0) in both denominators doesn't SIGFPE!
+  // Modifying dn *or* dncopy gives a SIGFPE!
+  dncopy.val /= 3.0;
+  dncopy.deriv /= 3.0;
+
+  DualNumber<double, NumberArray<N, double>> broken_conversion{dn};
+
+  return 0;
+}

--- a/test/run_unit_tests.sh.in
+++ b/test/run_unit_tests.sh.in
@@ -11,7 +11,7 @@ run_program() {
     }
 
 
-for prog in compare_types complex_derivs derivs divgrad \
+for prog in avoid_spurious_fpe compare_types complex_derivs derivs divgrad \
     dynamic_sparse_vector_pde identities instantiations main \
     nd_derivs parallel pde shadow_dynamic_sparse_vector_pde \
     shadow_sparse_struct_pde \


### PR DESCRIPTION
This adds the most stripped down test I could get to give me a spurious `FE_INVALID` from clang 15/16, and adds the configure infrastructure to make sure we *stop* getting those in the default configuration.