### PR TITLE
Assert read-only-access is into initialized memory

### DIFF
--- a/src/utilities/include/metaphysicl/dynamic_std_array_wrapper.h
+++ b/src/utilities/include/metaphysicl/dynamic_std_array_wrapper.h
@@ -113,7 +113,7 @@ public:
 
   const T & operator[](size_type i) const
   {
-    metaphysicl_assert(i < N);
+    metaphysicl_assert(i < _dynamic_n);
     return _data[i];
   }
 


### PR DESCRIPTION
In the vein of our conversations about possible use of uninitialized memory. To be honest I should also do this for the non-const access. I will have to change the unit test