### PR TITLE
Suppress gcc -Wmaybe-uninitialized

### DIFF
--- a/src/utilities/include/metaphysicl/dynamic_std_array_wrapper.h
+++ b/src/utilities/include/metaphysicl/dynamic_std_array_wrapper.h
@@ -55,14 +55,14 @@ public:
   {
     _dynamic_n = src._dynamic_n;
     metaphysicl_assert(_dynamic_n <= N);
-  #ifdef __GNUC__
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-  #endif
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     std::copy(src.begin(), src.end(), _data.begin());
-  #ifdef __GNUC__
-  #pragma GCC diagnostic pop
-  #endif
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
   }
 
   // A std::array isn't movable but it's contents might be
@@ -79,14 +79,14 @@ public:
   {
     _dynamic_n = src._dynamic_n;
     metaphysicl_assert(_dynamic_n <= N);
-  #ifdef __GNUC__
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-  #endif
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     std::copy(src.begin(), src.end(), _data.begin());
-  #ifdef __GNUC__
-  #pragma GCC diagnostic pop
-  #endif
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
     return *this;
   }
 


### PR DESCRIPTION
I can confirm that this workaround makes moose compilation in opt mode warning-free.