### PR TITLE
Send users to correct issues URL

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT([metaphysicl], [2.0.0], [https://github.com/libMesh/MetaPhysicL/issues])
+AC_INIT([metaphysicl], [2.0.0], [https://github.com/roystgnr/MetaPhysicL/issues])
 AC_CONFIG_MACRO_DIR([m4])
 
 AC_CONFIG_HEADERS([src/utilities/include/metaphysicl/metaphysicl_config.h.tmp])


### PR DESCRIPTION
We don't even have issues enabled at libMesh/MetaPhysicL at the moment. We made the choice (the details escape me) to bifurcate the locations of issues and PRs. I believe the latter's location is for ease of CI testing, and the former's is perhaps for history