### PR TITLE
Fix Kokkos build infrastructure for non-CUDA backends

### DIFF
--- a/m4/kokkos.m4
+++ b/m4/kokkos.m4
@@ -127,10 +127,11 @@ AC_DEFUN([CONFIGURE_KOKKOS],
         ;;
       openmp)
         KOKKOS_CXX="$CXX"
-        KOKKOS_CXXFLAGS="-fopenmp $KOKKOS_CXXFLAGS"
+        KOKKOS_CXXFLAGS="-fopenmp -x c++ $KOKKOS_CXXFLAGS"
         ;;
       serial|*)
         KOKKOS_CXX="$CXX"
+        KOKKOS_CXXFLAGS="-x c++ $KOKKOS_CXXFLAGS"
         ;;
     esac
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -169,16 +169,17 @@ kokkos_sparse_derivs_unit_LDFLAGS  = $(AM_LDFLAGS)  $(KOKKOS_LDFLAGS)
 kokkos_sparse_derivs_unit_LDADD    = $(KOKKOS_LIBS) $(LIBS)
 
 .K.o:
-	$(KOKKOS_CXX) \
-	  $(kokkos_sparse_derivs_unit_CPPFLAGS) \
-	  $(kokkos_sparse_derivs_unit_CXXFLAGS) \
-	  -x c++ \
+	$(KOKKOS_CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) \
+	  $(AM_CPPFLAGS) $(CPPFLAGS) $(KOKKOS_CPPFLAGS) \
+	  $(AM_CXXFLAGS) $(CXXFLAGS) $(KOKKOS_CXXFLAGS) \
 	  -c $< -o $@
 
-# Force this target’s link step to use the Kokkos compiler/wrapper
+# Force this target’s link step to use the Kokkos compiler/wrapper.
+# $(LDFLAGS) must be explicit here because this overrides the default
+# CXXLINK (which includes it); libtool --mode=link handles .la archives.
 kokkos_sparse_derivs_unit_LINK = \
   $(LIBTOOL) --tag=CXX --mode=link $(KOKKOS_CXX) \
-  $(kokkos_sparse_derivs_unit_LDFLAGS) -o $@
+  $(LDFLAGS) $(kokkos_sparse_derivs_unit_LDFLAGS) -o $@
 
 CLEANFILES =
 


### PR DESCRIPTION
kokkos.m4: move --forward-unknown-to-host-compiler to CUDA-only path; add -x c++ to KOKKOS_CXXFLAGS for openmp and serial backends so the host compiler treats .K files as C++.

test/Makefile.am: fix .K.o rule to compile directly (not via libtool) so the object file lands where the linker expects it; add $(CPPFLAGS) and $(CXXFLAGS) for transitive include paths (e.g. timpi); add $(LDFLAGS) explicitly to the custom kokkos_sparse_derivs_unit link command so -L paths for dependent libraries are not dropped.