### PR TITLE
Add "-Wformat-nonliteral" to ignore_warnings.h

### DIFF
--- a/src/utilities/include/metaphysicl/ignore_warnings.h
+++ b/src/utilities/include/metaphysicl/ignore_warnings.h
@@ -107,6 +107,8 @@
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #pragma GCC diagnostic ignored "-Wdeprecated-copy"
 #pragma GCC diagnostic ignored "-Wclass-memaccess"
+// Ignore warnings from Kokkos passing printf formats through char *
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 #endif
 #endif // __GNUC__ && !__INTEL_COMPILER
 


### PR DESCRIPTION
The Ubuntu 26.4 Kokkos headers trigger this one for me, not within MetaPhysicL tests themselves somehow, but within an application via the MetaPhysicL includes.